### PR TITLE
Switch to docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Ernest Romero <ernest@unstable.build>"]
 description = "Experimental Linux I/O library"
 license-file = "LICENSE"
-documentation = "http://rux.unstable.build/rustdoc"
+documentation = "https://docs.rs/rux/"
 homepage = "http://rux.unstable.build"
 repository = "https://github.com/ernestrc/rux"
 


### PR DESCRIPTION
Hi ernestrc

I noticed your website is down. 
I switched the docs path to docs.rs because it is allways uptodate.

Regards, dns2utf8